### PR TITLE
Disable Media Library

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -3,6 +3,8 @@ backend:
   repo: dxw/playbook2
   branch: main
   open_authoring: true
+media_library:
+  name: 'disabled'
 media_folder: "_images"
 publish_mode: editorial_workflow
 show_preview_links: true

--- a/admin/index.html
+++ b/admin/index.html
@@ -14,5 +14,11 @@
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script>
+      CMS.registerMediaLibrary({
+        name: 'disabled',
+        init: () => ({ show: () => undefined, enableStandalone: () => false }),
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
The media library feature currently clashes with the editorial flow we have at the moment, as it uploads straight to the main branch.

Following https://github.com/netlify/netlify-cms/issues/1702 to disable this feature entirely for now