### PR TITLE
Show a yellow background on link targets

### DIFF
--- a/_sass/_page-content.scss
+++ b/_sass/_page-content.scss
@@ -1,3 +1,5 @@
+@use "./colours";
+
 .page-content {
   flex: 1;
   padding: 0.5em 2em 5em;
@@ -6,5 +8,21 @@
   > div {
     margin: 0 auto;
     max-width: 40em;
+
+    > h1,
+    > h2,
+    > h3,
+    > h4,
+    > h5,
+    > h6 {
+      margin-left: -0.5em;
+      margin-right: -0.5em;
+      padding-left: 0.5em;
+      padding-right: 0.5em;
+    }
+
+    :target {
+      background: colours.$yellow-light;
+    }
   }
 }


### PR DESCRIPTION
This highlights the selected heading, making it easier to discover.